### PR TITLE
Skeleton of generating templates with a repo dispatch workflow

### DIFF
--- a/.github/workflows/generate_templates.yml
+++ b/.github/workflows/generate_templates.yml
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------------------
+# Generate template excel sheets from a data model using schematic
+# ------------------------------------------------------------------------------
+name: generate-templates
+on:
+  repository_dispatch:
+    types: generate_templates
+  workflow_dispatch:
+  
+jobs:
+  auto-open-pr:
+    runs-on: ubuntu-latest
+    steps:        
+      - name: Test
+        run: echo 'Successfully triggered workflow via repo dispatch!'


### PR DESCRIPTION
manual workflow dispatch must be in the default branch. https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#configuring-a-workflow-to-run-manually